### PR TITLE
fix: dh_strip breaks riscv64-linux-gnu build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -90,6 +90,13 @@ ifdef BUILD_DEB2
 endif
 endif
 
+override_dh_strip:
+ifeq (${DEB_TARGET_MULTIARCH},riscv64-linux-gnu)
+	dh_strip -Xlibcrypt.so.1 --
+else
+	dh_strip --
+endif
+
 override_dh_auto_install:
 ifdef BUILD_DEB1
 	cd build-deb1/ && \


### PR DESCRIPTION
See [(libxcrypt/libcrypt1) 在 RISC-V 上构建出的动态库无效](https://github.com/linuxdeepin/developer-center/issues/12157).

On `riscv64-linux-gnu`, "strip" breaks `libcrypt.so.1.1.0`, the shared library. This is a temporary solution for that.

Note that `strip --strip-debug` does not corrupt the library, but this is not performed in this PR.